### PR TITLE
use `long` for dict size

### DIFF
--- a/src/getpy.cpp
+++ b/src/getpy.cpp
@@ -105,7 +105,7 @@ struct Dict {
     }
 
 
-    int __len__ () {
+    long __len__ () {
         return __dict.size();
     }
 


### PR DESCRIPTION
Hi, thanks for the library, it's very useful to me.

I noticed that "__len__" is downcasting the underlying dict size to an `int`.
On top of returning the wrong result, calling `len` on a dict of size > 2**31 raises `ValueError: __len__() should return >= 0`

Unrelated to this PR: I see that you removed support for `bool` as values. Is there a reason for that ?